### PR TITLE
Fix regression from my earlier commit.

### DIFF
--- a/src/main/kotlin/http.kt
+++ b/src/main/kotlin/http.kt
@@ -146,7 +146,7 @@ class HttpSeed(port: Int, baseUrlPath: String, privkeyPath: Path, private val cr
         val bits = msg.toByteString()
         wrapper.setPeerSeeds(bits)
         wrapper.setPubkey(privkey.getPubKey().toByteString())
-        wrapper.setSignature(privkey.sign(Sha256Hash.wrap(bits.toByteArray())).encodeToDER().toByteString())
+        wrapper.setSignature(privkey.sign(Sha256Hash.of(bits.toByteArray())).encodeToDER().toByteString())
         val baos = ByteArrayOutputStream()
         val zip = GZIPOutputStream(baos)
         wrapper.build().writeDelimitedTo(zip)


### PR DESCRIPTION
 Use Sha256Hash.of() rather than Sha256Hash.wrap() to calculate the hash for signing the protobuf.